### PR TITLE
Fix typos, wording in int.xaml version 126

### DIFF
--- a/MassEffectModManagerCore/modmanager/localizations/int.xaml
+++ b/MassEffectModManagerCore/modmanager/localizations/int.xaml
@@ -24,7 +24,7 @@
     <system:String x:Key="string_LogModMakerCompiler">Log ModMaker Compiler</system:String>
     <system:String x:Key="string_LogModUpdater">Log Mod Updater</system:String>
     <system:String x:Key="string_Checkforcontentupdates">Refresh ME3Tweaks services</system:String>
-    <system:String x:Key="string_ChecksME3Tweaksforupdatestovariousservices">Downloads the latest ME3Tweaks.com service information, which is used for things such as mod identification, ASIs, etc.&#10;This is done automatically once a day</system:String>
+    <system:String x:Key="string_ChecksME3Tweaksforupdatestovariousservices">Downloads the latest ME3Tweaks.com service information, which is used for features such as mod identification, ASIs, etc.&#10;This is done automatically once a day</system:String>
     <system:String x:Key="string_Reloadsmodsfromthemodlibrary">Refresh the mod library</system:String>
     <system:String x:Key="string_tooltip_reloadModsFromLibrary">Refreshes the list of available mods in the mod library</system:String>
     <system:String x:Key="string_Exit">Exit</system:String>
@@ -398,7 +398,7 @@
     <system:String x:Key="string_interp_syncedPlotManagerForGame">Synced Plot Manager for {0}</system:String>
     <!-- 0={target.Game.ToGameName()} -->
     <system:String x:Key="string_configurationToolsForSpecificMods">Configuration tools for specific mods</system:String>
-    <system:String x:Key="string_femShepVsBroShepCloneConfigurationUtility">FemShep vs BroShep: Clone Configuration Utility</system:String>
+    <system:String x:Key="string_femShepVsBroShepCloneConfigurationUtility">FemShep v BroShep: Clone Configuration Utility</system:String>
     <system:String x:Key="string_tooltip_descriptionFemShepVsBroShepTool">Allows you to configure the look of the clone in ME3/LE3</system:String>
     <system:String x:Key="string_testEmailMerge">Test Email Merge</system:String>
     <system:String x:Key="string_installHeadmorph">Install Headmorph</system:String>
@@ -1268,7 +1268,7 @@
     <!-- 0={FriendlyName} 1={imageHeight} -->
     <system:String x:Key="string_validation_alt_imageAssetMissingHeight">Alternate {0} specifies an image asset but does not set (or have a valid value for) ImageHeight. ImageHeight is required to be set on alternates that specify an image asset.</system:String>
     <!-- 0={FriendlyName} -->
-    <system:String x:Key="string_validation_alt_cannotUseHiddenWithOptionGroup">Alternate {0} cannot set 'Hidden' to true when using 'OptionGroup'.</system:String>
+    <system:String x:Key="string_validation_alt_cannotUseHiddenWithOptionGroup">Alternate {0} cannot set 'Hidden' to 'true' when using 'OptionGroup'.</system:String>
     <!-- 0={Alternate FriendlyName} -->
     <system:String x:Key="string_validation_alt_invalidHiddenValue">Alternate {0}'s 'Hidden' value can only be 'true' or 'false'. An invalid value was provided: {1}</system:String>
     <!-- 0={Alternate FriendlyName} 1={invalid value} -->
@@ -1610,7 +1610,7 @@
     <!-- 0={Invalid sort index integer} -->
     <system:String x:Key="string_interp_validation_modparsing_hardcodedDirNotFound">Mod specifies {0} task header, but the {1} directory was not found. Remove this task header if you are not using it.</system:String>
     <!-- 0={Task header} 1={Foldername} -->
-    <system:String x:Key="string_interp_validation_modparsing_improperPackedFile">Mod has file is improperly stored in the archive: {0}. Mods must be deployed from Mod Manager to properly work.</system:String>
+    <system:String x:Key="string_interp_validation_modparsing_improperPackedFile">Mod has file that is improperly stored in the archive: {0}. Mods must be deployed from Mod Manager to properly work.</system:String>
     <!-- 0={File path} -->
 
     <!-- Shared NO BACKUP -->
@@ -2279,7 +2279,7 @@
     <system:String x:Key="string_tooltip_removeAlternate">Remove alternate</system:String>
     <system:String x:Key="string_tooltip_moveAlternateUp">Move alternate up</system:String>
     <system:String x:Key="string_tooltip_moveAlternateDown">Move alternate down</system:String>
-    <system:String x:Key="string_mde_validation_customDLCUniqueNames">Source directories and destination directories for CustomDLC must be unique from each another.</system:String>
+    <system:String x:Key="string_mde_validation_customDLCUniqueNames">Source directories and destination directories for CustomDLC must be unique from each other.</system:String>
     <system:String x:Key="string_mde_dlcModControl">DLC mod control</system:String>
     <!-- As in "Use these options to control what DLC mods your mod will install"-->
 
@@ -2367,7 +2367,7 @@
     <system:String x:Key="string_interp_mergefile_invalidEnumPropertyValue">'propertyvalue' for EnumProperty must have a '.' in it to separate the enum type from the enum value</system:String>
     <system:String xml:space="preserve" x:Key="string_interp_fileLibInitMergeMod1Script">FileLib for script update could not initialize, cannot merge script to {0}:\n{1}</system:String>
     <!-- 0={target entry InstancedFullPath} 1={newline split list of errors} -->
-    <system:String x:Key="string_interp_mergefile_noLocalizedFiles">Could not find any localized files to merge into for {0}. This merge has 'applytoallapplications' set to true, which makes changes only be merged into localized versions of a file</system:String>
+    <system:String x:Key="string_interp_mergefile_noLocalizedFiles">Could not find any localized files to merge into for {0}. This merge has 'applytoallapplications' set to true, which merges changes only into localized versions of a file</system:String>
     <!-- 0={FileName} -->
     <system:String x:Key="string_interp_mergefile_errorCompilingClassAfterEdit">Error compiling class {0} after adding or replacing {1}: {2}</system:String>
     <!-- 0={targetExport InstancedFullPath} 1={Script Filename} 2={list of errors} -->
@@ -2448,5 +2448,5 @@
 
     <!-- Texture Installer Panel -->
     <system:String x:Key="string_massEffectModderFiles">Mass Effect Modder files</system:String>
-    <!-- Mass Effect Modder is a proper noun so it probably shouldn't be localized. THis is prefix to a filter so its like Mass Effect Modder Files|*.mem -->
+    <!-- Mass Effect Modder is a proper noun so it probably shouldn't be localized. This is prefix to a filter so its like Mass Effect Modder Files|*.mem -->
 </ResourceDictionary>


### PR DESCRIPTION
- you started single quoting some stuff that are literals in the moddesc, but only sometimes. this remains to be fixed. (best run some regex over all localizations?)
- i would suggest you replace these techincal terms that can't be localized because they're literals/proper nouns by placeholders. e.g. `'OptionGroup'` => `{0}`
- i would suggest you break some strings down more to avoid redundancy, e.g.
![image](https://user-images.githubusercontent.com/2803622/178800570-3c77f28f-4e20-4071-a539-65604b447066.png)


I don't think the source for that is in here, but rather in your webservices that may not be open source.
![image](https://user-images.githubusercontent.com/2803622/178797629-e3c2c139-d91a-4d72-9a72-456c979ed176.png)
still, I think "need tested" -> "need to be tested"

Similarly in the pinned directions: "where almost all strings that need localized reside."